### PR TITLE
fix(details_log): update log messages for clarity and consistency (#1 and #2)

### DIFF
--- a/src/core/Optimizer.cpp
+++ b/src/core/Optimizer.cpp
@@ -137,7 +137,7 @@ namespace Reducord::Core::Optimizer
 			}
 
 			logger.Info("Found " + std::to_string(stats.total_files_count) +
-						"(" + Utils::FormattedSize(stats.total_size_bytes) + ")"
+						" (" + Utils::FormattedSize(stats.total_size_bytes) + ")"
 						" files");
 
 			size_t deleted = 0;
@@ -156,7 +156,8 @@ namespace Reducord::Core::Optimizer
 			}
 
 			logger.Success("Cleanup finished. Removed " + std::to_string(deleted) +
-						   "(" + Utils::FormattedSize(total) + ")" " files");
+						   " (" + Utils::FormattedSize(stats.total_size_bytes) + ")"
+						   " files");
 		}
 	};
 


### PR DESCRIPTION
- Now there're spaces between the words (#1)
- Now correct argument `total_size_bytes` passed to formatting function (#2)